### PR TITLE
Adding ToC for the rest of validation's steps

### DIFF
--- a/custom_validator/.ipynb_checkpoints/manual_data_validator-checkpoint.ipynb
+++ b/custom_validator/.ipynb_checkpoints/manual_data_validator-checkpoint.ipynb
@@ -17,7 +17,13 @@
     "\n",
     "The purpose of this validator is to highlight the errors inside the provided by the client data that will prevent its use.\n",
     "\n",
-    "This data validator does not fix any issues inside the data since it's not the purpose of this tool. \n"
+    "This data validator does not fix any issues inside the data since it's not the purpose of this tool. \n",
+    "\n",
+    "---------\n",
+    "\n",
+    "This Jupyter notebook is a representation of how logical technical validation works. \n",
+    "\n",
+    "The presented outcome of the cells results from the actual validation of the client's data.\n"
    ]
   },
   {
@@ -39,7 +45,41 @@
     "    - [Inventory Mandatory Columns](#Inventory-Mandatory-Columns)\n",
     "    - [Inventory Data type check](#Inventory-Data-type-check)\n",
     "    - [Inventory Missing values check](#Inventory-Missing-values-check)\n",
-    "    - [Inventory Numeric values range check](#Inventory-Numeric-values-range-check)"
+    "    - [Inventory Numeric values range check](#Inventory-Numeric-values-range-check)\n",
+    "  - [Locations](#Locations)\n",
+    "    - [Locations Mandatory Columns](#Locations-Mandatory-Columns)\n",
+    "    - [Locations Data type check](#Locations-Data-type-check)\n",
+    "    - [Locations Missing values check](#Locations-Missing-values-check)\n",
+    "    - [Locations Enum validation](#Locations-Enum-validation)\n",
+    "  - [Transactions](#Transactions)\n",
+    "    - [Transactions Mandatory Columns](#Transactions-Mandatory-Columns)\n",
+    "    - [Transactions Data type check](#Transactions-Data-type-check)\n",
+    "    - [Transactions Missing values check](#Transactions-Missing-values-check)\n",
+    "    - [Transactions Enum validation](#Transactions-Enum-validation)\n",
+    "- [Logical Validation](#Logical-Validation)\n",
+    "  - [Catalog Logical Validation](#Catalog-Logical-Validation)\n",
+    "    - [SKU ID is a unique value across all rows](#SKU-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [For each SKU, at least price or cost should be bigger than 0](#For-each-SKU,-at-least-price-or-cost-should-be-bigger-than-0)\n",
+    "    - [All SKUs of a product should have the same categories](#All-SKUs-of-a-product-should-have-the-same-categories)\n",
+    "    - [All SKUs of a product should have the same color](#All-SKUs-of-a-product-should-have-the-same-color)\n",
+    "    - [Number of unique sizes in a product should be equal to the number of SKUs](#Number-of-unique-sizes-in-a-product-should-be-equal-to-the-number-of-SKUs)\n",
+    "    - [At least 1 SKU is not on avoid replenishment](#At-least-1-SKU-is-not-on-avoid-replenishment)\n",
+    "  - [Inventory Logical Validation](#Inventory-Logical-Validation)\n",
+    "    - [At least 1 inventory is not on avoid replenishment](#At-least-1-inventory-is-not-on-avoid-replenishment)\n",
+    "    - [All the Locations exist in the DB or input files](#All-the-Locations-exist-in-the-DB-or-input-files)\n",
+    "    - [All the SKUs exist in the Catalog](#All-the-SKUs-exist-in-the-Catalog)\n",
+    "  - [Locations Logical Validation](#Locations-Logical-Validation)\n",
+    "    - [Location ID is a unique value across all rows](#Location-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [There is at least 1 location from type “store”](#There-is-at-least-1-location-from-type-store)\n",
+    "    - [There is at least 1 location from type “warehouse”](#There-is-at-least-1-location-from-type-warehouse)\n",
+    "    - [All the location types are from the optional values list](#All-the-location-types-are-from-the-optional-values-list)\n",
+    "    - [At least 1 location is not on avoid replenishment](#At-least-1-location-is-not-on-avoid-replenishment)\n",
+    "  - [Transactions Logical Validation](#Transactions-Logical-Validation)\n",
+    "    - [Transaction ID is a unique value across all rows](#Transaction-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [Source location is different from the target location](#Source-location-is-different-from-the-target-location)\n",
+    "    - [Source location OR Target location exist as a known location](#Source-location-OR-Target-location-exist-as-a-known-location)\n",
+    "    - [All SKU_ids exist in the catalog](#All-SKU_ids-exist-in-the-catalog)\n",
+    "    - [SKU_id exist in the Source location OR Target location](#SKU_id-exist-in-the-Source-location-OR-Target-location)"
    ]
   },
   {
@@ -603,6 +643,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c0bec29a-8a23-4541-bbf7-43f2d1349e16",
+   "metadata": {},
+   "source": [
+    "### Locations Mandatory Columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "52ee4d66-893c-4625-bda4-0b638f026067",
    "metadata": {},
    "source": [
@@ -649,7 +697,7 @@
    "id": "55d74320-9ac5-40ce-97ed-7ace23544bfe",
    "metadata": {},
    "source": [
-    "### Dtype check\n",
+    "### Locations Data type check\n",
     "\n",
     "Chacks if the column can be transformed in to the data type that the sustem expects"
    ]
@@ -696,7 +744,7 @@
    "id": "017dd4c9-eb01-483f-b186-4b26293e2837",
    "metadata": {},
    "source": [
-    "### Missing values check\n",
+    "### Locations Missing values check\n",
     "\n",
     "Check if the column contains any null values."
    ]
@@ -731,9 +779,9 @@
    "id": "2bb7ef17-1372-4ca8-a3a7-d015392903b4",
    "metadata": {},
    "source": [
-    "### Enum validation\n",
+    "### Locations Enum validation\n",
     "\n",
-    "Checks if the location types are in expected range of values. Expected types: ['store', 'warehouse', 'vwarehouse','ecommerce', 'plant', 'supplier','outlet', 'unknown', 'client']"
+    "Check if the location types are in the expected range of values. Expected types: ['store', 'warehouse', 'vwarehouse','ecommerce', 'plant', 'supplier','outlet', 'unknown', 'client']"
    ]
   },
   {
@@ -767,8 +815,22 @@
    "id": "7fbad530-a592-4e7a-ba5f-58d1f7925662",
    "metadata": {},
    "source": [
-    "### Transactions\n",
-    "\n",
+    "### Transactions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02f2fe46-e0e2-46ba-92c7-6621a68bef1a",
+   "metadata": {},
+   "source": [
+    "## Transactions Mandatory Columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "075f75b3-3ff6-4ac3-8c24-8a18c6fceb47",
+   "metadata": {},
+   "source": [
     "Checking that all the mandator columns are present, columns - ['id','sku_id','source_location_id','target_location_id','quantity','type','transaction_date']"
    ]
   },
@@ -817,7 +879,7 @@
    "id": "81865aa6-ad7e-4e35-a55f-4ebb68be8b37",
    "metadata": {},
    "source": [
-    "### Dtype check\n",
+    "### Transactions Data type check\n",
     "\n",
     "Chacks if the column can be transformed in to the data type that the sustem expects"
    ]
@@ -873,7 +935,7 @@
    "id": "4f77e327-b32e-4d36-bdd6-ea325401ce66",
    "metadata": {},
    "source": [
-    "### Missing values check\n",
+    "### Transactions Missing values check\n",
     "\n",
     "Checks if the column contains any null values."
    ]
@@ -912,7 +974,7 @@
    "id": "10157139-c4fe-4265-a461-74942a53667c",
    "metadata": {},
    "source": [
-    "### Enum validation\n",
+    "### Transactions Enum validation\n",
     "\n",
     "Checks if the transactions types are in expected range of values. Expected types: **['in', 'out', 'sale']**"
    ]
@@ -959,7 +1021,7 @@
    "id": "028c451e-6baa-4bea-80f7-85df3d04bf2b",
    "metadata": {},
    "source": [
-    "### Numeric values range check\n",
+    "### Transactions Numeric values range check\n",
     "\n",
     "Checks if the values in the column are in expected range. quantity can't be less then 0"
    ]
@@ -996,8 +1058,7 @@
    "id": "2fe430fa-a78f-45a5-9a26-aebc61e3ea57",
    "metadata": {},
    "source": [
-    "# Logical Validation\n",
-    "---"
+    "# Logical Validation"
    ]
   },
   {
@@ -1005,7 +1066,7 @@
    "id": "f109bf24-60de-40a5-91b7-41fead171d4f",
    "metadata": {},
    "source": [
-    "## Catalog Logical Validation\n"
+    "## Catalog Logical Validation"
    ]
   },
   {
@@ -1388,7 +1449,7 @@
    "id": "c5ea6665-e08f-4dd5-bb90-61d6a44fd38b",
    "metadata": {},
    "source": [
-    "### There is at least 1 location from type “store”"
+    "### There is at least 1 location from type store"
    ]
   },
   {
@@ -1418,7 +1479,7 @@
    "id": "ff7ce2c6-206e-4e08-aa74-dabd12d994b1",
    "metadata": {},
    "source": [
-    "### There is at least 1 location from type “warehouse”"
+    "### There is at least 1 location from type warehouse"
    ]
   },
   {
@@ -1448,7 +1509,8 @@
    "id": "0dfd8e98-1797-4543-9466-e16cb3e60bad",
    "metadata": {},
    "source": [
-    "### All the location types are from the optional values list (wh/store/plant/supplier/client/unknown)"
+    "### All the location types are from the optional values list\n",
+    "List: wh/store/plant/supplier/client/unknown"
    ]
   },
   {
@@ -1462,7 +1524,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[91mInvalid location types found:\u001b[0m\n",
-      "{'Warehouse', 'Shop', 'Warehouse '}\n"
+      "{'Warehouse ', 'Shop', 'Warehouse'}\n"
      ]
     }
    ],
@@ -1705,32 +1767,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "da995516-f936-45bf-af9b-dc7a4ae36ccb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[91mSKUs for which both SKU_id - target_location_id and SKU_id - source_location_id don't exist in df_inventory:\u001b[0m\n",
-      "            sku_id source_location_id target_location_id\n",
-      "0              UR1                501                  1\n",
-      "1              UR1                502                  4\n",
-      "2              UR1                503                  6\n",
-      "3              UR1                504                  7\n",
-      "4              UR1                505                  8\n",
-      "...            ...                ...                ...\n",
-      "1043555  921519KSH            1049071                  9\n",
-      "1043556  921519KSH            1049072                  9\n",
-      "1043557  921519KSH            1049073                  9\n",
-      "1043558  921519KSH            1049074                  9\n",
-      "1043559  921519KSH            1049075                  9\n",
-      "\n",
-      "[1043560 rows x 3 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "inventory_sku_location_combinations = set(zip(df_inventory['sku_id'], df_inventory['location_id']))\n",
     "\n",

--- a/custom_validator/manual_data_validator.ipynb
+++ b/custom_validator/manual_data_validator.ipynb
@@ -17,7 +17,13 @@
     "\n",
     "The purpose of this validator is to highlight the errors inside the provided by the client data that will prevent its use.\n",
     "\n",
-    "This data validator does not fix any issues inside the data since it's not the purpose of this tool. \n"
+    "This data validator does not fix any issues inside the data since it's not the purpose of this tool. \n",
+    "\n",
+    "---------\n",
+    "\n",
+    "This Jupyter notebook is a representation of how logical technical validation works. \n",
+    "\n",
+    "The presented outcome of the cells results from the actual validation of the client's data.\n"
    ]
   },
   {
@@ -39,7 +45,41 @@
     "    - [Inventory Mandatory Columns](#Inventory-Mandatory-Columns)\n",
     "    - [Inventory Data type check](#Inventory-Data-type-check)\n",
     "    - [Inventory Missing values check](#Inventory-Missing-values-check)\n",
-    "    - [Inventory Numeric values range check](#Inventory-Numeric-values-range-check)"
+    "    - [Inventory Numeric values range check](#Inventory-Numeric-values-range-check)\n",
+    "  - [Locations](#Locations)\n",
+    "    - [Locations Mandatory Columns](#Locations-Mandatory-Columns)\n",
+    "    - [Locations Data type check](#Locations-Data-type-check)\n",
+    "    - [Locations Missing values check](#Locations-Missing-values-check)\n",
+    "    - [Locations Enum validation](#Locations-Enum-validation)\n",
+    "  - [Transactions](#Transactions)\n",
+    "    - [Transactions Mandatory Columns](#Transactions-Mandatory-Columns)\n",
+    "    - [Transactions Data type check](#Transactions-Data-type-check)\n",
+    "    - [Transactions Missing values check](#Transactions-Missing-values-check)\n",
+    "    - [Transactions Enum validation](#Transactions-Enum-validation)\n",
+    "- [Logical Validation](#Logical-Validation)\n",
+    "  - [Catalog Logical Validation](#Catalog-Logical-Validation)\n",
+    "    - [SKU ID is a unique value across all rows](#SKU-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [For each SKU, at least price or cost should be bigger than 0](#For-each-SKU,-at-least-price-or-cost-should-be-bigger-than-0)\n",
+    "    - [All SKUs of a product should have the same categories](#All-SKUs-of-a-product-should-have-the-same-categories)\n",
+    "    - [All SKUs of a product should have the same color](#All-SKUs-of-a-product-should-have-the-same-color)\n",
+    "    - [Number of unique sizes in a product should be equal to the number of SKUs](#Number-of-unique-sizes-in-a-product-should-be-equal-to-the-number-of-SKUs)\n",
+    "    - [At least 1 SKU is not on avoid replenishment](#At-least-1-SKU-is-not-on-avoid-replenishment)\n",
+    "  - [Inventory Logical Validation](#Inventory-Logical-Validation)\n",
+    "    - [At least 1 inventory is not on avoid replenishment](#At-least-1-inventory-is-not-on-avoid-replenishment)\n",
+    "    - [All the Locations exist in the DB or input files](#All-the-Locations-exist-in-the-DB-or-input-files)\n",
+    "    - [All the SKUs exist in the Catalog](#All-the-SKUs-exist-in-the-Catalog)\n",
+    "  - [Locations Logical Validation](#Locations-Logical-Validation)\n",
+    "    - [Location ID is a unique value across all rows](#Location-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [There is at least 1 location from type “store”](#There-is-at-least-1-location-from-type-store)\n",
+    "    - [There is at least 1 location from type “warehouse”](#There-is-at-least-1-location-from-type-warehouse)\n",
+    "    - [All the location types are from the optional values list](#All-the-location-types-are-from-the-optional-values-list)\n",
+    "    - [At least 1 location is not on avoid replenishment](#At-least-1-location-is-not-on-avoid-replenishment)\n",
+    "  - [Transactions Logical Validation](#Transactions-Logical-Validation)\n",
+    "    - [Transaction ID is a unique value across all rows](#Transaction-ID-is-a-unique-value-across-all-rows)\n",
+    "    - [Source location is different from the target location](#Source-location-is-different-from-the-target-location)\n",
+    "    - [Source location OR Target location exist as a known location](#Source-location-OR-Target-location-exist-as-a-known-location)\n",
+    "    - [All SKU_ids exist in the catalog](#All-SKU_ids-exist-in-the-catalog)\n",
+    "    - [SKU_id exist in the Source location OR Target location](#SKU_id-exist-in-the-Source-location-OR-Target-location)"
    ]
   },
   {
@@ -603,6 +643,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c0bec29a-8a23-4541-bbf7-43f2d1349e16",
+   "metadata": {},
+   "source": [
+    "### Locations Mandatory Columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "52ee4d66-893c-4625-bda4-0b638f026067",
    "metadata": {},
    "source": [
@@ -649,7 +697,7 @@
    "id": "55d74320-9ac5-40ce-97ed-7ace23544bfe",
    "metadata": {},
    "source": [
-    "### Dtype check\n",
+    "### Locations Data type check\n",
     "\n",
     "Chacks if the column can be transformed in to the data type that the sustem expects"
    ]
@@ -696,7 +744,7 @@
    "id": "017dd4c9-eb01-483f-b186-4b26293e2837",
    "metadata": {},
    "source": [
-    "### Missing values check\n",
+    "### Locations Missing values check\n",
     "\n",
     "Check if the column contains any null values."
    ]
@@ -731,9 +779,9 @@
    "id": "2bb7ef17-1372-4ca8-a3a7-d015392903b4",
    "metadata": {},
    "source": [
-    "### Enum validation\n",
+    "### Locations Enum validation\n",
     "\n",
-    "Checks if the location types are in expected range of values. Expected types: ['store', 'warehouse', 'vwarehouse','ecommerce', 'plant', 'supplier','outlet', 'unknown', 'client']"
+    "Check if the location types are in the expected range of values. Expected types: ['store', 'warehouse', 'vwarehouse','ecommerce', 'plant', 'supplier','outlet', 'unknown', 'client']"
    ]
   },
   {
@@ -767,8 +815,22 @@
    "id": "7fbad530-a592-4e7a-ba5f-58d1f7925662",
    "metadata": {},
    "source": [
-    "### Transactions\n",
-    "\n",
+    "### Transactions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02f2fe46-e0e2-46ba-92c7-6621a68bef1a",
+   "metadata": {},
+   "source": [
+    "## Transactions Mandatory Columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "075f75b3-3ff6-4ac3-8c24-8a18c6fceb47",
+   "metadata": {},
+   "source": [
     "Checking that all the mandator columns are present, columns - ['id','sku_id','source_location_id','target_location_id','quantity','type','transaction_date']"
    ]
   },
@@ -817,7 +879,7 @@
    "id": "81865aa6-ad7e-4e35-a55f-4ebb68be8b37",
    "metadata": {},
    "source": [
-    "### Dtype check\n",
+    "### Transactions Data type check\n",
     "\n",
     "Chacks if the column can be transformed in to the data type that the sustem expects"
    ]
@@ -873,7 +935,7 @@
    "id": "4f77e327-b32e-4d36-bdd6-ea325401ce66",
    "metadata": {},
    "source": [
-    "### Missing values check\n",
+    "### Transactions Missing values check\n",
     "\n",
     "Checks if the column contains any null values."
    ]
@@ -912,7 +974,7 @@
    "id": "10157139-c4fe-4265-a461-74942a53667c",
    "metadata": {},
    "source": [
-    "### Enum validation\n",
+    "### Transactions Enum validation\n",
     "\n",
     "Checks if the transactions types are in expected range of values. Expected types: **['in', 'out', 'sale']**"
    ]
@@ -959,7 +1021,7 @@
    "id": "028c451e-6baa-4bea-80f7-85df3d04bf2b",
    "metadata": {},
    "source": [
-    "### Numeric values range check\n",
+    "### Transactions Numeric values range check\n",
     "\n",
     "Checks if the values in the column are in expected range. quantity can't be less then 0"
    ]
@@ -996,8 +1058,7 @@
    "id": "2fe430fa-a78f-45a5-9a26-aebc61e3ea57",
    "metadata": {},
    "source": [
-    "# Logical Validation\n",
-    "---"
+    "# Logical Validation"
    ]
   },
   {
@@ -1005,7 +1066,7 @@
    "id": "f109bf24-60de-40a5-91b7-41fead171d4f",
    "metadata": {},
    "source": [
-    "## Catalog Logical Validation\n"
+    "## Catalog Logical Validation"
    ]
   },
   {
@@ -1388,7 +1449,7 @@
    "id": "c5ea6665-e08f-4dd5-bb90-61d6a44fd38b",
    "metadata": {},
    "source": [
-    "### There is at least 1 location from type “store”"
+    "### There is at least 1 location from type store"
    ]
   },
   {
@@ -1418,7 +1479,7 @@
    "id": "ff7ce2c6-206e-4e08-aa74-dabd12d994b1",
    "metadata": {},
    "source": [
-    "### There is at least 1 location from type “warehouse”"
+    "### There is at least 1 location from type warehouse"
    ]
   },
   {
@@ -1448,7 +1509,8 @@
    "id": "0dfd8e98-1797-4543-9466-e16cb3e60bad",
    "metadata": {},
    "source": [
-    "### All the location types are from the optional values list (wh/store/plant/supplier/client/unknown)"
+    "### All the location types are from the optional values list\n",
+    "List: wh/store/plant/supplier/client/unknown"
    ]
   },
   {
@@ -1462,7 +1524,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[91mInvalid location types found:\u001b[0m\n",
-      "{'Warehouse', 'Shop', 'Warehouse '}\n"
+      "{'Warehouse ', 'Shop', 'Warehouse'}\n"
      ]
     }
    ],
@@ -1705,32 +1767,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "da995516-f936-45bf-af9b-dc7a4ae36ccb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[91mSKUs for which both SKU_id - target_location_id and SKU_id - source_location_id don't exist in df_inventory:\u001b[0m\n",
-      "            sku_id source_location_id target_location_id\n",
-      "0              UR1                501                  1\n",
-      "1              UR1                502                  4\n",
-      "2              UR1                503                  6\n",
-      "3              UR1                504                  7\n",
-      "4              UR1                505                  8\n",
-      "...            ...                ...                ...\n",
-      "1043555  921519KSH            1049071                  9\n",
-      "1043556  921519KSH            1049072                  9\n",
-      "1043557  921519KSH            1049073                  9\n",
-      "1043558  921519KSH            1049074                  9\n",
-      "1043559  921519KSH            1049075                  9\n",
-      "\n",
-      "[1043560 rows x 3 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "inventory_sku_location_combinations = set(zip(df_inventory['sku_id'], df_inventory['location_id']))\n",
     "\n",


### PR DESCRIPTION
Adding the rest of the ToC headings. 

Now all of the validation steps have a proper link and can be found easily by the user. 
![image](https://github.com/user-attachments/assets/ede0ecff-9e19-4aab-ab41-6a78c1f46e30)
